### PR TITLE
ci: 改用 PAT_TOKEN 觸發 release workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -15,6 +15,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PAT_TOKEN }}
 
       - name: Read version from pyproject.toml
         id: version


### PR DESCRIPTION
## Summary
- 修正 `auto-tag.yml` 改用 `PAT_TOKEN` 推 tag

## Why
`GITHUB_TOKEN` 推的操作不會觸發其他 workflow，導致 tag 建立後 `release.yml` 不會自動執行。改用 PAT 推 tag 可以正常觸發。
